### PR TITLE
Fix vocab sizes wrt. reserved tokens

### DIFF
--- a/pie/data/dataset.py
+++ b/pie/data/dataset.py
@@ -256,7 +256,7 @@ class LabelEncoder(object):
             slots_left = self.max_size - len(self.inverse_table)
             if slots_left > 0:                
                 if slots_left < len(new_chars):
-                    logger.info(f"Could not register all available uppercase vocab entries "
+                    logger.info(f"Could not register all available uppercase {self.name} vocab entries "
                                 f"({slots_left} slots < {len(new_chars)} upper chars)")
                 else:
                     logger.info(f"All uppercase ({self.name}) vocab registered ({len(new_chars)} new entries)")
@@ -264,7 +264,7 @@ class LabelEncoder(object):
             else:
                 if len(new_chars) > 0:
                     logger.info(f"Could not register all available uppercase vocab entries "
-                                f"({len(new_chars)} upper chars not registered)")
+                                f"({len(new_chars)} upper {self.name} entries not registered)")
                 return # We have too much in the vocab already
         
         # Add new chars to the vocabulary


### PR DESCRIPTION
Different methods in LabelEncoder class were altering the final vocabulary size when self.max_size is set, because the reserved entries were not always handled identically, leading to more or fewer model parameters than requested depending on the options passed.

This PR fixes this by counting the reserved tokens as part of max_size.

In practice:
- compute_vocab will remove more entries to leave space for the reserved ones
- expand_vocab will substract the reserved tokens when counting the number of slots left
- expand_vocab will no longer erroneously expand the size of the vocab when max_size is set to shrink the new vocab size
- register_upper will no longer substract reserved entries twice to count the number of slots left

Additionally, in expand_vocab the min_freq condition is applied at the same time as the filtering to find new symbols, for optimization purpose